### PR TITLE
Remove use of nested/aliased withState module.

### DIFF
--- a/client/apps/main/routes.js
+++ b/client/apps/main/routes.js
@@ -8,7 +8,8 @@ export const routes = {
   },
   users: {
     path: '/users',
-    component: Users
+    component: Users,
+    isAuthed: () => false
   }
 }
 

--- a/client/project/elements/dropdown/index.js
+++ b/client/project/elements/dropdown/index.js
@@ -1,10 +1,11 @@
 import {pathOr, pipe, filter} from 'wasmuth'
 
+import withState from '/util/withState'
+
 import {
   set,
   dispatch,
-  getState,
-  withState
+  getState
 } from '/store'
 
 import BaseDropdown from './base'

--- a/client/project/elements/page-notification/index.js
+++ b/client/project/elements/page-notification/index.js
@@ -1,5 +1,6 @@
 import {guid, path} from 'wasmuth'
-import {withState, dispatch, set, update, getState} from '/store'
+import withState from '/util/withState'
+import {dispatch, set, update, getState} from '/store'
 import Base from './base'
 
 export const PageNotification = withState(

--- a/client/project/elements/pagination/index.js
+++ b/client/project/elements/pagination/index.js
@@ -1,10 +1,10 @@
 import {path} from 'wasmuth'
 import {route as preactRoute} from 'preact-router'
 
+import withState from '/util/withState'
 import {urlFor} from '/util/route'
 import {updateQuery} from '/util/updateQuery'
 
-import {withState} from '/store'
 import {PAGE_SIZE} from '/settings'
 
 import Base from './base'

--- a/client/project/elements/styled-form/checkbox/index.js
+++ b/client/project/elements/styled-form/checkbox/index.js
@@ -1,4 +1,5 @@
-import {withState, dispatch, update} from '/store'
+import withState from '/util/withState'
+import {dispatch, update} from '/store'
 
 export const Checkbox = withState('Checkbox',
   ({forms = {}}, {formName, name}) => ({

--- a/client/project/modals/index.js
+++ b/client/project/modals/index.js
@@ -1,4 +1,4 @@
-import {withState} from '/store'
+import withState from '/util/withState'
 import Example from './example'
 
 const MODALS = {

--- a/client/project/pages/not-found/index.js
+++ b/client/project/pages/not-found/index.js
@@ -1,4 +1,4 @@
-import {withState} from '/store'
+import withState from '/util/withState'
 import Base from './base'
 
 export const NotFound = withState(

--- a/client/store.js
+++ b/client/store.js
@@ -2,9 +2,8 @@ import {createStore} from 'redux'
 import {watchStore} from 'wasmuth'
 import {composeWithDevTools} from 'redux-devtools-extension'
 
-import {pathReducer, actions} from '/util/pathReducer'
-import withStateUtil from '/util/withState'
-import getStorageItem from '/util/getStorageItem'
+import {pathReducer, actions} from './util/pathReducer'
+import getStorageItem from './util/getStorageItem'
 
 import {DEBUG} from '/settings'
 
@@ -28,5 +27,4 @@ export const set = actions.set
 export const update = actions.update
 export const remove = actions.remove
 export const watchPath = watchStore(store)
-export const withState = withStateUtil
 export default store


### PR DESCRIPTION
Nested/aliased imports seem to have undefined issues at runtime. Likely because the full dependency path is not resolved in the time the code is executed. Kinda scary. Not sure if this is a babel or brunch issue.

In other words:

`util/withState -> store -> SomeFile` Will throw.
`util/withState -> SomeFile` Works.

This is a pretty dangerous issue surrounding  modules. Perhaps a note should be added to README as well? (and I some point actually resolved)